### PR TITLE
Fixed bug when getting documents by groupId

### DIFF
--- a/mms-ent/repo-amp/src/main/java/gov/nasa/jpl/view_repo/util/EmsNodeUtil.java
+++ b/mms-ent/repo-amp/src/main/java/gov/nasa/jpl/view_repo/util/EmsNodeUtil.java
@@ -508,6 +508,9 @@ public class EmsNodeUtil {
         return results;
     }
 
+    public JSONArray getDocJson(String sysmlId, String commitId, boolean extended) {
+        return getDocJson(sysmlId, commitId, extended, 10000);
+    }
     /**
      * Get the documents that exist in a site at a specified time
      *
@@ -515,7 +518,7 @@ public class EmsNodeUtil {
      * @param commitId Commit ID to look up documents at
      * @return JSONArray of the documents in the site
      */
-    public JSONArray getDocJson(String sysmlId, String commitId, boolean extended) {
+    public JSONArray getDocJson(String sysmlId, String commitId, boolean extended, int depth) {
 
         JSONArray result = new JSONArray();
         List<Node> docNodes = pgh.getNodesByType(DbNodeTypes.DOCUMENT);
@@ -525,7 +528,7 @@ public class EmsNodeUtil {
             docSysml2Elastic.put(node.getSysmlId(), node.getElasticId());
         });
 
-        List<Pair<String, String>> siteChildren = pgh.getChildren(sysmlId, DbEdgeTypes.CONTAINMENT, 10000);
+        List<Pair<String, String>> siteChildren = pgh.getChildren(sysmlId, DbEdgeTypes.CONTAINMENT, depth);
         Set<String> siteChildrenIds = new HashSet<>();
         siteChildren.forEach((child) -> {
             siteChildrenIds.add(child.first);

--- a/mms-ent/repo-amp/src/main/java/gov/nasa/jpl/view_repo/webscripts/ProductsGet.java
+++ b/mms-ent/repo-amp/src/main/java/gov/nasa/jpl/view_repo/webscripts/ProductsGet.java
@@ -87,9 +87,10 @@ public class ProductsGet extends AbstractJavaWebScript {
         String refId = getRefId(req);
         String projectId = getProjectId(req);
         String extended = req.getParameter("extended");
+        String depth = req.getParameter("depth");
         String groupId = req.getServiceMatch().getTemplateVars().get("groupId");
 
         EmsNodeUtil emsNodeUtil = new EmsNodeUtil(projectId, refId);
-        return emsNodeUtil.getDocJson((groupId != null && !groupId.equals("")) ? groupId : projectId, commitId, extended != null && extended.equals("true"));
+        return emsNodeUtil.getDocJson((groupId != null && !groupId.equals("")) ? groupId : projectId, commitId, extended != null && extended.equals("true"), groupId != null ?  depth != null ? Integer.parseInt(depth) : 1 : 10000 );
     }
 }

--- a/mms-ent/runner/src/test/robotframework/JsonData/PostNestedDocument.json
+++ b/mms-ent/runner/src/test/robotframework/JsonData/PostNestedDocument.json
@@ -5,7 +5,47 @@
             "ownerId": "package2",
             "name": "doc2",
             "_appliedStereotypeIds": [
-                "_17_0_1_232f03dc_1325612611695_581988_21583"
+                "_17_0_2_3_87b0275_1371477871400_792964_43374"
+            ],
+            "type": "Class"
+        },
+        {
+            "id": "doc3",
+            "ownerId": "doc1",
+            "name": "doc3",
+            "documentation": "This is a depth of 1 doc.",
+            "_appliedStereotypeIds": [
+                "_17_0_2_3_87b0275_1371477871400_792964_43374"
+            ],
+            "type": "Class"
+        },
+        {
+            "id": "doc4",
+            "ownerId": "doc1",
+            "name": "doc4",
+            "documentation": "This is a depth of 1 doc.",
+            "_appliedStereotypeIds": [
+                "_17_0_2_3_87b0275_1371477871400_792964_43374"
+            ],
+            "type": "Class"
+        },
+        {
+            "id": "doc5",
+            "ownerId": "doc2",
+            "name": "doc5",
+            "documentation": "This is a depth of 2 doc.",
+            "_appliedStereotypeIds": [
+                "_17_0_2_3_87b0275_1371477871400_792964_43374"
+            ],
+            "type": "Class"
+        },
+        {
+            "id": "doc6",
+            "ownerId": "doc3",
+            "name": "doc6",
+            "documentation": "This is a depth of 3 doc.",
+            "_appliedStereotypeIds": [
+                "_17_0_2_3_87b0275_1371477871400_792964_43374"
             ],
             "type": "Class"
         }

--- a/mms-ent/runner/src/test/robotframework/output/baseline/GetDocumentsAndNestedDocsFromPA.json
+++ b/mms-ent/runner/src/test/robotframework/output/baseline/GetDocumentsAndNestedDocsFromPA.json
@@ -1,12 +1,30 @@
 {
-    "_creator": "admin",
-    "elements": [
+    "documents": [
         {
             "_appliedStereotypeIds": [
                 "_17_0_2_3_87b0275_1371477871400_792964_43374"
             ],
+            "_childViews": [],
             "_creator": "admin",
             "_editable": true,
+            "_groupId": "group1",
+            "_modifier": "admin",
+            "_projectId": "PA",
+            "_refId": "master",
+            "documentation": "This is a depth of 3 doc.",
+            "id": "doc6",
+            "name": "doc6",
+            "ownerId": "doc3",
+            "type": "Class"
+        },
+        {
+            "_appliedStereotypeIds": [
+                "_17_0_2_3_87b0275_1371477871400_792964_43374"
+            ],
+            "_childViews": [],
+            "_creator": "admin",
+            "_editable": true,
+            "_groupId": "group2",
             "_modifier": "admin",
             "_projectId": "PA",
             "_refId": "master",
@@ -19,38 +37,10 @@
             "_appliedStereotypeIds": [
                 "_17_0_2_3_87b0275_1371477871400_792964_43374"
             ],
+            "_childViews": [],
             "_creator": "admin",
             "_editable": true,
-            "_modifier": "admin",
-            "_projectId": "PA",
-            "_refId": "master",
-            "documentation": "This is a depth of 1 doc.",
-            "id": "doc3",
-            "name": "doc3",
-            "ownerId": "doc1",
-            "type": "Class"
-        },
-        {
-            "_appliedStereotypeIds": [
-                "_17_0_2_3_87b0275_1371477871400_792964_43374"
-            ],
-            "_creator": "admin",
-            "_editable": true,
-            "_modifier": "admin",
-            "_projectId": "PA",
-            "_refId": "master",
-            "documentation": "This is a depth of 1 doc.",
-            "id": "doc4",
-            "name": "doc4",
-            "ownerId": "doc1",
-            "type": "Class"
-        },
-        {
-            "_appliedStereotypeIds": [
-                "_17_0_2_3_87b0275_1371477871400_792964_43374"
-            ],
-            "_creator": "admin",
-            "_editable": true,
+            "_groupId": "group2",
             "_modifier": "admin",
             "_projectId": "PA",
             "_refId": "master",
@@ -64,15 +54,65 @@
             "_appliedStereotypeIds": [
                 "_17_0_2_3_87b0275_1371477871400_792964_43374"
             ],
+            "_childViews": [],
+            "_creator": "admin",
+            "_editable": true,
+            "_groupId": "group1",
+            "_modifier": "admin",
+            "_projectId": "PA",
+            "_refId": "master",
+            "documentation": "This is a depth of 1 doc.",
+            "id": "doc3",
+            "name": "doc3",
+            "ownerId": "doc1",
+            "type": "Class"
+        },
+        {
+            "_appliedStereotypeIds": [
+                "_17_0_2_3_87b0275_1371477871400_792964_43374"
+            ],
+            "_childViews": [],
+            "_creator": "admin",
+            "_editable": true,
+            "_groupId": "group1",
+            "_modifier": "admin",
+            "_projectId": "PA",
+            "_refId": "master",
+            "documentation": "This is a depth of 1 doc.",
+            "id": "doc4",
+            "name": "doc4",
+            "ownerId": "doc1",
+            "type": "Class"
+        },
+        {
+            "_appliedStereotypeIds": [
+                "_17_0_2_3_87b0275_1371477871400_792964_43374"
+            ],
+            "_childViews": [],
+            "_creator": "admin",
+            "_editable": true,
+            "_groupId": "group1",
+            "_modifier": "admin",
+            "_projectId": "PA",
+            "_refId": "master",
+            "id": "doc1",
+            "name": "doc1",
+            "ownerId": "group1",
+            "type": "Class"
+        },
+        {
+            "_appliedStereotypeIds": [
+                "_17_0_2_3_87b0275_1371477871400_792964_43374"
+            ],
+            "_childViews": [],
             "_creator": "admin",
             "_editable": true,
             "_modifier": "admin",
             "_projectId": "PA",
             "_refId": "master",
-            "documentation": "This is a depth of 3 doc.",
-            "id": "doc6",
-            "name": "doc6",
-            "ownerId": "doc3",
+            "id": "doc0",
+            "name": "doc0",
+            "ownerId": "PA",
             "type": "Class"
         }
     ]

--- a/mms-ent/runner/src/test/robotframework/output/baseline/GetDocumentsFromPA.json
+++ b/mms-ent/runner/src/test/robotframework/output/baseline/GetDocumentsFromPA.json
@@ -7,6 +7,22 @@
             "_childViews": [],
             "_creator": "admin",
             "_editable": true,
+            "_groupId": "group1",
+            "_modifier": "admin",
+            "_projectId": "PA",
+            "_refId": "master",
+            "id": "doc1",
+            "name": "doc1",
+            "ownerId": "group1",
+            "type": "Class"
+        },
+        {
+            "_appliedStereotypeIds": [
+                "_17_0_2_3_87b0275_1371477871400_792964_43374"
+            ],
+            "_childViews": [],
+            "_creator": "admin",
+            "_editable": true,
             "_modifier": "admin",
             "_projectId": "PA",
             "_refId": "master",
@@ -29,22 +45,6 @@
             "id": "doc2",
             "name": "doc2",
             "ownerId": "package2",
-            "type": "Class"
-        },
-        {
-            "_appliedStereotypeIds": [
-                "_17_0_2_3_87b0275_1371477871400_792964_43374"
-            ],
-            "_childViews": [],
-            "_creator": "admin",
-            "_editable": true,
-            "_groupId": "group1",
-            "_modifier": "admin",
-            "_projectId": "PA",
-            "_refId": "master",
-            "id": "doc1",
-            "name": "doc1",
-            "ownerId": "group1",
             "type": "Class"
         }
     ]

--- a/mms-ent/runner/src/test/robotframework/output/baseline/GetDoumentByGroupId.json
+++ b/mms-ent/runner/src/test/robotframework/output/baseline/GetDoumentByGroupId.json
@@ -1,0 +1,20 @@
+{
+    "documents": [
+        {
+            "_appliedStereotypeIds": [
+                "_17_0_2_3_87b0275_1371477871400_792964_43374"
+            ],
+            "_childViews": [],
+            "_creator": "admin",
+            "_editable": true,
+            "_groupId": "group1",
+            "_modifier": "admin",
+            "_projectId": "PA",
+            "_refId": "master",
+            "id": "doc1",
+            "name": "doc1",
+            "ownerId": "group1",
+            "type": "Class"
+        }
+    ]
+}

--- a/mms-ent/runner/src/test/robotframework/output/baseline/GetDoumentByGroupIdWithDepth1.json
+++ b/mms-ent/runner/src/test/robotframework/output/baseline/GetDoumentByGroupIdWithDepth1.json
@@ -1,0 +1,20 @@
+{
+    "documents": [
+        {
+            "_appliedStereotypeIds": [
+                "_17_0_2_3_87b0275_1371477871400_792964_43374"
+            ],
+            "_childViews": [],
+            "_creator": "admin",
+            "_editable": true,
+            "_groupId": "group1",
+            "_modifier": "admin",
+            "_projectId": "PA",
+            "_refId": "master",
+            "id": "doc1",
+            "name": "doc1",
+            "ownerId": "group1",
+            "type": "Class"
+        }
+    ]
+}

--- a/mms-ent/runner/src/test/robotframework/output/baseline/GetDoumentByGroupIdWithDepth2.json
+++ b/mms-ent/runner/src/test/robotframework/output/baseline/GetDoumentByGroupIdWithDepth2.json
@@ -7,12 +7,31 @@
             "_childViews": [],
             "_creator": "admin",
             "_editable": true,
+            "_groupId": "group1",
             "_modifier": "admin",
             "_projectId": "PA",
             "_refId": "master",
-            "id": "doc0",
-            "name": "doc0",
-            "ownerId": "PA",
+            "documentation": "This is a depth of 1 doc.",
+            "id": "doc3",
+            "name": "doc3",
+            "ownerId": "doc1",
+            "type": "Class"
+        },
+        {
+            "_appliedStereotypeIds": [
+                "_17_0_2_3_87b0275_1371477871400_792964_43374"
+            ],
+            "_childViews": [],
+            "_creator": "admin",
+            "_editable": true,
+            "_groupId": "group1",
+            "_modifier": "admin",
+            "_projectId": "PA",
+            "_refId": "master",
+            "documentation": "This is a depth of 1 doc.",
+            "id": "doc4",
+            "name": "doc4",
+            "ownerId": "doc1",
             "type": "Class"
         },
         {

--- a/mms-ent/runner/src/test/robotframework/output/baseline/GetDoumentByGroupIdWithDepth3.json
+++ b/mms-ent/runner/src/test/robotframework/output/baseline/GetDoumentByGroupIdWithDepth3.json
@@ -1,26 +1,30 @@
 {
-    "_creator": "admin",
-    "elements": [
+    "documents": [
         {
             "_appliedStereotypeIds": [
                 "_17_0_2_3_87b0275_1371477871400_792964_43374"
             ],
+            "_childViews": [],
             "_creator": "admin",
             "_editable": true,
+            "_groupId": "group1",
             "_modifier": "admin",
             "_projectId": "PA",
             "_refId": "master",
-            "id": "doc2",
-            "name": "doc2",
-            "ownerId": "package2",
+            "documentation": "This is a depth of 3 doc.",
+            "id": "doc6",
+            "name": "doc6",
+            "ownerId": "doc3",
             "type": "Class"
         },
         {
             "_appliedStereotypeIds": [
                 "_17_0_2_3_87b0275_1371477871400_792964_43374"
             ],
+            "_childViews": [],
             "_creator": "admin",
             "_editable": true,
+            "_groupId": "group1",
             "_modifier": "admin",
             "_projectId": "PA",
             "_refId": "master",
@@ -34,8 +38,26 @@
             "_appliedStereotypeIds": [
                 "_17_0_2_3_87b0275_1371477871400_792964_43374"
             ],
+            "_childViews": [],
             "_creator": "admin",
             "_editable": true,
+            "_groupId": "group2",
+            "_modifier": "admin",
+            "_projectId": "PA",
+            "_refId": "master",
+            "id": "doc2",
+            "name": "doc2",
+            "ownerId": "package2",
+            "type": "Class"
+        },
+        {
+            "_appliedStereotypeIds": [
+                "_17_0_2_3_87b0275_1371477871400_792964_43374"
+            ],
+            "_childViews": [],
+            "_creator": "admin",
+            "_editable": true,
+            "_groupId": "group1",
             "_modifier": "admin",
             "_projectId": "PA",
             "_refId": "master",
@@ -49,30 +71,16 @@
             "_appliedStereotypeIds": [
                 "_17_0_2_3_87b0275_1371477871400_792964_43374"
             ],
+            "_childViews": [],
             "_creator": "admin",
             "_editable": true,
+            "_groupId": "group1",
             "_modifier": "admin",
             "_projectId": "PA",
             "_refId": "master",
-            "documentation": "This is a depth of 2 doc.",
-            "id": "doc5",
-            "name": "doc5",
-            "ownerId": "doc2",
-            "type": "Class"
-        },
-        {
-            "_appliedStereotypeIds": [
-                "_17_0_2_3_87b0275_1371477871400_792964_43374"
-            ],
-            "_creator": "admin",
-            "_editable": true,
-            "_modifier": "admin",
-            "_projectId": "PA",
-            "_refId": "master",
-            "documentation": "This is a depth of 3 doc.",
-            "id": "doc6",
-            "name": "doc6",
-            "ownerId": "doc3",
+            "id": "doc1",
+            "name": "doc1",
+            "ownerId": "group1",
             "type": "Class"
         }
     ]

--- a/mms-ent/runner/src/test/robotframework/robot_lib.py
+++ b/mms-ent/runner/src/test/robotframework/robot_lib.py
@@ -26,7 +26,7 @@ Get Sites
 develop_baseline_dir = '../developBaselineDir/'
 debug_test = False
 ROOT_RETURN_ELEMENTS = ['elements', 'refs', 'configurations', 'products', 'sites', 'views', 'ownersNotFound',
-                        'message', 'workspace1', 'workspace2']
+                        'message', 'workspace1', 'workspace2', 'documents']
 
 robot_dir = os.getcwd() + '/runner/src/test/robotframework'
 output_dir = os.listdir(robot_dir + '/output')

--- a/mms-ent/runner/src/test/robotframework/suites/10__groups_and_docs/01__master.robot
+++ b/mms-ent/runner/src/test/robotframework/suites/10__groups_and_docs/01__master.robot
@@ -49,8 +49,8 @@ PostNestedDocument
 	${compare_result} =		Compare JSON		${TEST_NAME}
 	Should Match Baseline		${compare_result}
 
-GetDocumentsFromPAWithoutDoc2
-	[Documentation]		"get documents without doc2"
+GetDocumentsAndNestedDocsFromPA
+	[Documentation]		"Get all documents from PA"
 	[Tags]				G5
 	${result} =			Get		url=${ROOT}/projects/PA/refs/master/documents		headers=&{REQ_HEADER}
 	Should Be Equal		${result.status_code}		${200}
@@ -59,4 +59,52 @@ GetDocumentsFromPAWithoutDoc2
 	${compare_result} =		Compare JSON		${TEST_NAME}
 	Should Match Baseline		${compare_result}
 
+GetDoumentByGroupId
+    [Documentation]  "Get documents by groupId from PA"
+    [Tags]           G6
+	${result} =			Get		url=${ROOT}/projects/PA/refs/master/documents/group1		headers=&{REQ_HEADER}
+	Should Be Equal		${result.status_code}		${200}
+	${filter} =			Create List     _commitId		nodeRefId		 versionedRefId		 _created		 read		 lastModified		 _modified		 siteCharacterizationId		 time_total		 _elasticId		 _timestamp		 _inRefIds
+	Generate JSON		${TEST_NAME}		${result.json()}		${filter}
+	${compare_result} =		Compare JSON		${TEST_NAME}
+	Should Match Baseline		${compare_result}
 
+GetDoumentByGroupIdWithDepth1
+    [Documentation]  "Get documents by groupId and depth at 1 from PA"
+    [Tags]           G7
+	${result} =			Get		url=${ROOT}/projects/PA/refs/master/documents/group1?depth=1		headers=&{REQ_HEADER}
+	Should Be Equal		${result.status_code}		${200}
+	${filter} =			Create List     _commitId		nodeRefId		 versionedRefId		 _created		 read		 lastModified		 _modified		 siteCharacterizationId		 time_total		 _elasticId		 _timestamp		 _inRefIds
+	Generate JSON		${TEST_NAME}		${result.json()}		${filter}
+	${compare_result} =		Compare JSON		${TEST_NAME}
+	Should Match Baseline		${compare_result}
+
+GetDoumentByGroupIdWithDepth2
+    [Documentation]  "Get documents by groupId and depth at 2 from PA"
+    [Tags]           G8
+	${result} =			Get		url=${ROOT}/projects/PA/refs/master/documents/group1?depth=2		headers=&{REQ_HEADER}
+	Should Be Equal		${result.status_code}		${200}
+	${filter} =			Create List     _commitId		nodeRefId		 versionedRefId		 _created		 read		 lastModified		 _modified		 siteCharacterizationId		 time_total		 _elasticId		 _timestamp		 _inRefIds
+	Generate JSON		${TEST_NAME}		${result.json()}		${filter}
+	${compare_result} =		Compare JSON		${TEST_NAME}
+	Should Match Baseline		${compare_result}
+
+GetDoumentByGroupIdWithDepth3
+    [Documentation]  "Get documents by groupId and depth at 3 from PA"
+    [Tags]           G9
+	${result} =			Get		url=${ROOT}/projects/PA/refs/master/documents/group1?depth=3		headers=&{REQ_HEADER}
+	Should Be Equal		${result.status_code}		${200}
+	${filter} =			Create List     _commitId		nodeRefId		 versionedRefId		 _created		 read		 lastModified		 _modified		 siteCharacterizationId		 time_total		 _elasticId		 _timestamp		 _inRefIds
+	Generate JSON		${TEST_NAME}		${result.json()}		${filter}
+	${compare_result} =		Compare JSON		${TEST_NAME}
+	Should Match Baseline		${compare_result}
+
+GetDoumentByGroupIdWithInvalidDepth
+    [Documentation]  "Get documents by groupId and an invalid depth."
+    [Tags]           G10
+	${result} =			Get		url=${ROOT}/projects/PA/refs/master/documents/group1?depth=invalidDepth		headers=&{REQ_HEADER}
+	Should Be Equal		${result.status_code}		${500}
+#	${filter} =			Create List     _commitId		nodeRefId		 versionedRefId		 _created		 read		 lastModified		 _modified		 siteCharacterizationId		 time_total		 _elasticId		 _timestamp		 _inRefIds
+#	Generate JSON		${TEST_NAME}		${result.json()}		${filter}
+#	${compare_result} =		Compare JSON		${TEST_NAME}
+#	Should Match Baseline		${compare_result}


### PR DESCRIPTION
Can now get documents based on groupId and specify the depth at which to get the nested elements. Added multiple tests to verify different depths and invalidity. Removed old test that became redundant with new tests for getting documents.