### PR TITLE
Fixed the delete failed error during tests.

### DIFF
--- a/mms-ent/repo-amp/src/main/java/gov/nasa/jpl/view_repo/db/ElasticHelper.java
+++ b/mms-ent/repo-amp/src/main/java/gov/nasa/jpl/view_repo/db/ElasticHelper.java
@@ -532,7 +532,7 @@ public class ElasticHelper {
         try {
             result = client.execute(deleteByQuery);
             if (!result.isSucceeded()) {
-                logger.error("Delete Failed!");
+                logger.error("Deleting Elastic Elements Failed!");
                 logger.error(result.getErrorMessage());
             }
         } catch (Exception e) {

--- a/mms-ent/repo-amp/src/main/java/gov/nasa/jpl/view_repo/db/PostgresHelper.java
+++ b/mms-ent/repo-amp/src/main/java/gov/nasa/jpl/view_repo/db/PostgresHelper.java
@@ -2141,11 +2141,10 @@ public class PostgresHelper {
      */
     public void dropDatabase(String databaseName) {
 
-        PostgresPool.removeConnection(EmsConfig.get("pg.host"), databaseName);
-
-        String query = "ALTER DATABASE  \"_" + databaseName  +"\" CONNECTION LIMIT 0";
-        String query2 = "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = \'_" + databaseName +"\'";
-        String query3 = "DROP DATABASE \"_" + databaseName +"\";";
+        String query = "ALTER DATABASE  \"_" + databaseName + "\" CONNECTION LIMIT 0";
+        String query2 =
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = \'_" + databaseName + "\'";
+        String query3 = "DROP DATABASE \"_" + databaseName + "\";";
 
         connectConfig();
 
@@ -2153,10 +2152,23 @@ public class PostgresHelper {
             this.configConn.createStatement().executeUpdate(query);
             this.configConn.prepareCall(query2).execute();
             this.configConn.createStatement().executeUpdate(query3);
+
+            // Should only try to remove the connection from postgres if the queries succeed.
+            PostgresPool.removeConnection(EmsConfig.get("pg.host"), databaseName);
         } catch (SQLException e) {
-            logger.warn(String.format("%s", LogUtil.getStackTrace(e)));
+
+            logger.error(String.format("%s", LogUtil.getStackTrace(e)));
+
+            // If any of the queries fail, reset the connection limit of the database
+            query = "ALTER DATABASE  \"_" + databaseName + "\" CONNECTION LIMIT -1";
+            try {
+                this.configConn.createStatement().executeUpdate(query);
+            } catch (SQLException e2) {
+                logger.warn(String.format("%s", LogUtil.getStackTrace(e2)));
+            }
+        } finally {
+            closeConfig();
         }
-        closeConfig();
     }
 
     /**

--- a/mms-ent/runner/src/test/robotframework/JsonData/PostNewElementsForDeleteProject.json
+++ b/mms-ent/runner/src/test/robotframework/JsonData/PostNewElementsForDeleteProject.json
@@ -1,0 +1,206 @@
+{
+    "elements": [
+        {
+            "documentation": "Delete something",
+            "id": "delete_300",
+            "name": "three hundred",
+            "ownerId": "DeleteProject",
+            "type": "Property",
+            "isDerived": false,
+            "value": [
+                {
+                    "type": "LiteralString",
+                    "string": "dlam_string"
+                }
+            ]
+        },
+        {
+            "documentation": "Delete else",
+            "id": "delete_301",
+            "name": "three hundred and one",
+            "ownerId": "delete_300",
+            "type": "Property",
+            "isDerived": false,
+            "value": [
+                {
+                    "type": "LiteralString",
+                    "string": "dlam_string"
+                }
+            ]
+        },
+        {
+            "documentation": "Delete to",
+            "id": "delete_302",
+            "name": "three hundred and two",
+            "ownerId": "delete_301",
+            "type": "Property",
+            "isDerived": false,
+            "value": [
+                {
+                    "type": "LiteralString",
+                    "string": "dlam_string"
+                }
+            ]
+        },
+        {
+            "documentation": "Delete talk",
+            "id": "delete_303",
+            "name": "three hundred and three",
+            "ownerId": "delete_302",
+            "type": "Property",
+            "isDerived": false,
+            "value": [
+                {
+                    "type": "LiteralString",
+                    "string": "dlam_string"
+                }
+            ]
+        },
+        {
+            "documentation": "Delete about",
+            "id": "delete_304",
+            "name": "three hundred and four",
+            "ownerId": "delete_303",
+            "type": "Property",
+            "isDerived": false,
+            "value": [
+                {
+                    "type": "LiteralString",
+                    "string": "dlam_string"
+                }
+            ]
+        },
+        {
+            "documentation": "Delete no owner",
+            "id": "delete_305",
+            "name": "three hundred and five",
+            "ownerId": null,
+            "type": "Property",
+            "isDerived": false,
+            "value": [
+                {
+                    "type": "LiteralString",
+                    "string": "dlam_string"
+                }
+            ]
+        },
+        {
+            "documentation": "Delete 4something",
+            "id": "delete_4000",
+            "name": "four hundred",
+            "ownerId": "DeleteProject",
+            "type": "Property",
+            "isDerived": false,
+            "value": [
+                {
+                    "type": "LiteralString",
+                    "string": "dlam_string"
+                }
+            ]
+        },
+        {
+            "documentation": "Delete 4else",
+            "id": "delete_401",
+            "name": "four hundred and one",
+            "ownerId": "delete_4000",
+            "type": "Property",
+            "isDerived": false,
+            "value": [
+                {
+                    "type": "LiteralString",
+                    "string": "dlam_string"
+                }
+            ]
+        },
+        {
+            "documentation": "Delete 4to",
+            "id": "delete_402",
+            "name": "four hundred and two",
+            "ownerId": "delete_401",
+            "type": "Property",
+            "isDerived": false,
+            "value": [
+                {
+                    "type": "LiteralString",
+                    "string": "dlam_string"
+                }
+            ]
+        },
+        {
+            "documentation": "Delete 4talk",
+            "id": "delete_403",
+            "name": "four hundred and three",
+            "ownerId": "delete_402",
+            "type": "Property",
+            "isDerived": false,
+            "value": [
+                {
+                    "type": "LiteralString",
+                    "string": "dlam_string"
+                }
+            ]
+        },
+        {
+            "documentation": "Delete 4about",
+            "id": "delete_404",
+            "name": "four hundred and four",
+            "ownerId": "delete_403",
+            "type": "Property",
+            "isDerived": false,
+            "value": [
+                {
+                    "type": "LiteralString",
+                    "string": "dlam_string"
+                }
+            ]
+        },
+        {
+            "documentation": "Delete element values",
+            "id": "delete_600",
+            "ownerId": null,
+            "name": "Delete 600",
+            "type": "Property",
+            "value": [
+                {
+                    "type": "ElementValue",
+                    "element": "delete_300"
+                },
+                {
+                    "type": "ElementValue",
+                    "element": "delete_302"
+                }
+            ]
+        },
+        {
+            "documentation": "Delete ",
+            "id": "delete_6666",
+            "ownerId": null,
+            "name": "6666_name",
+            "type": "Expression",
+            "operand": [
+                {
+                    "type": "ElementValue",
+                    "element": "delete_300"
+                },
+                {
+                    "type": "ElementValue",
+                    "element": "delete_302"
+                }
+            ]
+        },
+        {
+            "documentation": "Delete something",
+            "id": "delete_x",
+            "name": "xxx",
+            "ownerId": null,
+            "type": "Property",
+            "isDerived": false,
+            "value": [
+                {
+                    "type": "LiteralString",
+                    "string": "dlam_string"
+                }
+            ]
+        }
+    ]
+}

--- a/mms-ent/runner/src/test/robotframework/suites/01__crud/01__master.robot
+++ b/mms-ent/runner/src/test/robotframework/suites/01__crud/01__master.robot
@@ -122,6 +122,9 @@ DeleteProject
 	${post_json} =		Get File		${CURDIR}/../../JsonData/ProjectForDeleteProject.json
 	${result} =			Post			url=${ROOT}/orgs/initorg/projects			data=${post_json}		headers=&{REQ_HEADER}
 	Should Be Equal		${result.status_code}		${200}
+	${post_json} =		Get File		${CURDIR}/../../JsonData/PostNewElementsForDeleteProject.json
+	${result} =			Post			url=${ROOT}/projects/DeleteProject/refs/master/elements         data=${post_json}		headers=&{REQ_HEADER}
+	Should Be Equal		${result.status_code}		${200}
 	${result} =		 Delete	  url=${ROOT}/projects/${TEST_NAME}
 	Should Be Equal	 ${result.status_code}	   ${200}
 	${result} =			Get		url=${ROOT}/orgs/initorg/projects/${TEST_NAME}		headers=&{REQ_HEADER}

--- a/mms-ent/runner/src/test/robotframework/suites/01__crud/01__master.robot
+++ b/mms-ent/runner/src/test/robotframework/suites/01__crud/01__master.robot
@@ -122,9 +122,11 @@ DeleteProject
 	${post_json} =		Get File		${CURDIR}/../../JsonData/ProjectForDeleteProject.json
 	${result} =			Post			url=${ROOT}/orgs/initorg/projects			data=${post_json}		headers=&{REQ_HEADER}
 	Should Be Equal		${result.status_code}		${200}
+	Sleep				${POST_DELAY_INDEXING}
 	${post_json} =		Get File		${CURDIR}/../../JsonData/PostNewElementsForDeleteProject.json
 	${result} =			Post			url=${ROOT}/projects/DeleteProject/refs/master/elements         data=${post_json}		headers=&{REQ_HEADER}
 	Should Be Equal		${result.status_code}		${200}
+	Sleep				${POST_DELAY_INDEXING}
 	${result} =		 Delete	  url=${ROOT}/projects/${TEST_NAME}
 	Should Be Equal	 ${result.status_code}	   ${200}
 	${result} =			Get		url=${ROOT}/orgs/initorg/projects/${TEST_NAME}		headers=&{REQ_HEADER}


### PR DESCRIPTION
Made the delete failed a little bit more specific on what delete failed. Fixed the issue during the tests when it said it Delete Failed, the project did not have elements, therefore would fail the deletion. Updated postgreshelper to reset the connection limit if the delete queries failed for any reason and only to remove the connection from the pool if the delete is successful.