### PR TITLE
Record db error

### DIFF
--- a/mms-ent/repo-amp/src/main/java/gov/nasa/jpl/view_repo/db/GraphInterface.java
+++ b/mms-ent/repo-amp/src/main/java/gov/nasa/jpl/view_repo/db/GraphInterface.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.postgresql.util.PSQLException;
+
 public interface GraphInterface {
     String LASTCOMMIT = "lastCommit";
     String INITIALCOMMIT = "initialCommit";
@@ -157,7 +159,7 @@ public interface GraphInterface {
 
     void deleteEdges(String parentSysmlId, String childSysmlId, DbEdgeTypes dbet);
 
-    int createOrganization(String orgId, String orgName);
+    int createOrganization(String orgId, String orgName) throws PSQLException;
 
     void createProjectDatabase(String projectId, String orgId, String name, String location);
 

--- a/mms-ent/repo-amp/src/main/java/gov/nasa/jpl/view_repo/db/PostgresHelper.java
+++ b/mms-ent/repo-amp/src/main/java/gov/nasa/jpl/view_repo/db/PostgresHelper.java
@@ -22,6 +22,7 @@ import gov.nasa.jpl.view_repo.util.EmsConfig;
 import gov.nasa.jpl.view_repo.util.LogUtil;
 import gov.nasa.jpl.view_repo.util.EmsScriptNode;
 import org.postgresql.util.PSQLException;
+import org.postgresql.util.ServerErrorMessage;
 
 public class PostgresHelper implements GraphInterface {
     static Logger logger = Logger.getLogger(PostgresHelper.class);
@@ -1483,7 +1484,11 @@ public class PostgresHelper implements GraphInterface {
                 }
             }
         } catch (PSQLException pe) {
+            ServerErrorMessage em = pe.getServerErrorMessage();
             // Do nothing for duplicate found
+            if (!em.getConstraint().equals("unique_organizations")) {
+                logger.error(String.format("%s:%s", LogUtil.getStackTrace(pe), em));
+            }
         } catch (Exception e) {
             logger.warn(String.format("%s", LogUtil.getStackTrace(e)));
         } finally {

--- a/mms-ent/repo-amp/src/main/java/gov/nasa/jpl/view_repo/db/PostgresHelper.java
+++ b/mms-ent/repo-amp/src/main/java/gov/nasa/jpl/view_repo/db/PostgresHelper.java
@@ -1466,7 +1466,8 @@ public class PostgresHelper implements GraphInterface {
         }
     }
 
-    public int createOrganization(String orgId, String orgName) {
+    public int createOrganization(String orgId, String orgName) 
+    	throws PSQLException {
         int recordId = 0;
         try {
             connectConfig();
@@ -1487,7 +1488,7 @@ public class PostgresHelper implements GraphInterface {
             ServerErrorMessage em = pe.getServerErrorMessage();
             // Do nothing for duplicate found
             if (!em.getConstraint().equals("unique_organizations")) {
-                logger.error(String.format("%s:%s", LogUtil.getStackTrace(pe), em));
+                throw pe;
             }
         } catch (Exception e) {
             logger.warn(String.format("%s", LogUtil.getStackTrace(e)));

--- a/mms-ent/repo-amp/src/main/java/gov/nasa/jpl/view_repo/util/CommitUtil.java
+++ b/mms-ent/repo-amp/src/main/java/gov/nasa/jpl/view_repo/util/CommitUtil.java
@@ -28,6 +28,7 @@ import org.apache.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.postgresql.util.PSQLException;
 
 import gov.nasa.jpl.mbee.util.Pair;
 import gov.nasa.jpl.mbee.util.Timer;
@@ -623,7 +624,8 @@ public class CommitUtil {
         return true;
     }
 
-    public static void sendOrganizationDelta(String orgId, String orgName, String user) {
+    public static void sendOrganizationDelta(String orgId, String orgName, String user) throws PSQLException 
+    {
         PostgresHelper pgh = new PostgresHelper();
         pgh.createOrganization(orgId, orgName);
     }


### PR DESCRIPTION
If db throws an error while trying to create an org, it is trapped and
ignored. Checking for duplicate org and doing nothing in that case,
otherwise propagate the error back to webscript and return 500
