### PR TITLE
Added index.html to API documentation paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,12 +285,12 @@ API Documentation is located at the following endpoints:
 
 Swagger CodeGen:
 ```
-alfresco/mms
+alfresco/mms/index.html
 ```
 
 Swagger UI:
 ```
-alfresco/mms/swagger-ui
+alfresco/mms/swagger-ui/index.html
 ```
 
 Swagger YAML file:


### PR DESCRIPTION
The default Tomcat configuration doesn't serve HTML content. Explicit path to ensure it works regardless of config.